### PR TITLE
tracing deps are not optional and blocks compiling the lib

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,7 @@ all-features = true
 default = []
 native-tls = ["hyper-tls"]
 rustls = ["hyper-rustls", "tokio-rustls"]
-full = [ "hyper-staticfile", "async-compression", "tracing", "tracing-log" ]
+full = ["hyper-staticfile", "async-compression"]
 
 
 [dependencies]
@@ -35,8 +35,8 @@ hyper-rustls = { version = "0.22", optional = true }
 tokio-rustls = { version = "0.22", optional = true }
 hyper-staticfile = { version = "0.6", optional = true }
 async-compression = { version = "0.3", optional = true }
-tracing = { version="0.1", optional = true }
-tracing-log = { version="0.1", optional = true }
+tracing = { version="0.1"}
+tracing-log = { version="0.1"}
 
 [dependencies.hyper]
 features = ["server", "tcp", "http1", "http2"]


### PR DESCRIPTION
Tracing deps are not optional and are blocking compiling the lib for default feature. This MR attempts to fix that